### PR TITLE
Update Addon to use @ember/test-waiters

### DIFF
--- a/addon-test-support/register-waiter.js
+++ b/addon-test-support/register-waiter.js
@@ -1,8 +1,22 @@
 /* eslint-disable ember/no-legacy-test-waiters */
 import { registerWaiter as emberRegisterWaiter } from '@ember/test';
 import scheduler from 'ember-raf-scheduler';
+import { deprecate } from '@ember/debug';
 
 export default function registerWaiter() {
+  deprecate(
+    '`registerWaiter` is not longer required. This can now be safely removed.',
+    false,
+    {
+      id: 'ember-raf-scheduler.legacy-register-waiter',
+      until: '0.5.0',
+      for: 'ember-raf-scheduler',
+      since: {
+        available: '0.4.1',
+        enabled: '0.4.1',
+      },
+    }
+  );
   emberRegisterWaiter(function () {
     return scheduler.jobs === 0;
   });

--- a/addon/index.js
+++ b/addon/index.js
@@ -1,6 +1,9 @@
 import { DEBUG } from '@glimmer/env';
 import { begin, end } from '@ember/runloop';
 import { assert } from '@ember/debug';
+import { buildWaiter } from '@ember/test-waiters';
+
+const waiter = buildWaiter('ember-raf-scheduler-waiter');
 
 export class Token {
   constructor(parent) {
@@ -25,10 +28,12 @@ export class Token {
 }
 
 function job(cb, token) {
+  let jobToken = waiter.beginAsync();
   return function execJob() {
     if (token.cancelled === false) {
       cb();
     }
+    waiter.endAsync(jobToken);
   };
 }
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@ember/optional-features": "^2.0.0",
     "@ember/string": "^3.0.1",
     "@ember/test-helpers": "^2.9.3",
+    "@ember/test-waiters": "^3.1.0",
     "@embroider/test-setup": "^2.1.1",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@ember/string": "^3.0.1",
     "@ember/test-helpers": "^2.9.3",
     "@ember/test-waiters": "^3.1.0",
-    "@embroider/test-setup": "^2.1.1",
+    "@embroider/test-setup": "^4.0.0",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
     "broccoli-asset-rev": "^3.0.0",
@@ -73,7 +73,10 @@
     "stylelint": "^15.4.0",
     "stylelint-config-standard": "^32.0.0",
     "stylelint-prettier": "^3.0.0",
-    "webpack": "^5.78.0"
+    "webpack": "^5.0.0",
+    "@embroider/core": "^3.4.8",
+    "@embroider/webpack": "^4.0.0",
+    "@embroider/compat": "^3.4.8"
   },
   "peerDependencies": {
     "ember-source": "^3.12.0"

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -3,9 +3,6 @@ import config from 'dummy/config/environment';
 import { setApplication } from '@ember/test-helpers';
 import { start } from 'ember-qunit';
 
-import registerWaiter from 'ember-raf-scheduler/test-support/register-waiter';
 setApplication(Application.create(config.APP));
-
-registerWaiter();
 
 start();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1178,10 +1178,10 @@
     semver "^7.3.5"
     typescript-memoize "^1.0.1"
 
-"@embroider/test-setup@^2.1.1":
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@embroider/test-setup/-/test-setup-2.1.1.tgz#1cf613f479ed120fdc5d71cb834c8fb71514cce1"
-  integrity sha512-t81a2z2OEFAOZVbV7wkgiDuCyZ3ajD7J7J+keaTfNSRiXoQgeFFASEECYq1TCsH8m/R+xHMRiY59apF2FIeFhw==
+"@embroider/test-setup@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@embroider/test-setup/-/test-setup-4.0.0.tgz#080dd40314a53cc6f6fcffed41cd24ee0cb48b3d"
+  integrity sha512-1S3Ebk0CEh3XDqD93AWSwQZBCk+oGv03gtkaGgdgyXGIR7jrVyDgEnEuslN/hJ0cuU8TqhiXrzHMw7bJwIGhWw==
   dependencies:
     lodash "^4.17.21"
     resolve "^1.20.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1139,6 +1139,16 @@
     ember-cli-version-checker "^5.1.2"
     semver "^7.3.5"
 
+"@ember/test-waiters@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@ember/test-waiters/-/test-waiters-3.1.0.tgz#61399919cbf793978da0b8bfdfdb7bca0cb80e9e"
+  integrity sha512-bb9h95ktG2wKY9+ja1sdsFBdOms2lB19VWs8wmNpzgHv1NCetonBoV5jHBV4DHt0uS1tg9z66cZqhUVlYs96KQ==
+  dependencies:
+    calculate-cache-key-for-tree "^2.0.0"
+    ember-cli-babel "^7.26.6"
+    ember-cli-version-checker "^5.1.2"
+    semver "^7.3.5"
+
 "@embroider/macros@^1.0.0", "@embroider/macros@^1.10.0", "@embroider/macros@^1.13.0":
   version "1.13.1"
   resolved "https://registry.yarnpkg.com/@embroider/macros/-/macros-1.13.1.tgz#aee17e5af0e0086bd36873bdb4e49ea346bab3fa"


### PR DESCRIPTION
I've experienced some issues with the old test waiter system when using this addon with embroider builds #15 , this updates the addon to use the "new" test waiter system. This appears to fix my issue. 

Note: I added a deprecation message for `registerWaiter` to give time but open to just removing it in this PR.

Bumped `@embroider/test-setup` this should fix the embroider failures. 