### PR TITLE
fix: add waiter token to _flush so settled() waits for pending RAF

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -46,6 +46,7 @@ export class Scheduler {
     this.affect = [];
     this.jobs = 0;
     this._nextFlush = null;
+    this._flushToken = null;
     this.ticks = 0;
 
     if (macroCondition(isDevelopingApp())) {
@@ -80,6 +81,7 @@ export class Scheduler {
       return;
     }
 
+    this._flushToken = waiter.beginAsync();
     this._nextFlush = requestAnimationFrame(() => {
       this.flush();
     });
@@ -128,6 +130,7 @@ export class Scheduler {
     }
 
     this._nextFlush = null;
+    waiter.endAsync(this._flushToken);
     if (this.jobs > 0) {
       this._flush();
     }


### PR DESCRIPTION
## Summary

`_flush()` schedules work via `requestAnimationFrame` but has no test waiter token covering the RAF callback. This means `settled()` can return before the RAF fires, causing test failures with async data sources like PromiseArrays.

## Root cause

The individual `job()` waiter tokens only activate when scheduler work is queued. But `settled()` can "slip through" during the gap between when the RAF is scheduled and when it fires — there's no waiter telling `settled()` that async work is pending.

## Fix

3 lines:
- `waiter.beginAsync()` in `_flush()` when scheduling the RAF
- `waiter.endAsync()` in `flush()` after work completes
- Initialize `_flushToken` in the constructor (needed for `Object.seal` in dev)

## Reproduction

This was discovered in html-next/vertical-collection#522 where all `Static PromiseArray` tests failed (12 failures — some assertion failures, some 60s timeouts). The same fix applied there resolves all failures: html-next/vertical-collection#560

🤖 Generated with [Claude Code](https://claude.com/claude-code)